### PR TITLE
Add tests for asof joins with dictionary columns and implement naive solution

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -31,12 +31,9 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <iostream>
-
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/options.h"
 #include "arrow/acero/unmaterialized_table_internal.h"
-#include "arrow/type.h"
 #ifndef NDEBUG
 #  include "arrow/acero/options_internal.h"
 #endif
@@ -523,6 +520,7 @@ class InputState : public util::SerialSequencingQueue::Processor {
         underlying_schema_(underlying_schema),
         time_col_index_(time_col_index),
         key_col_index_(key_col_index),
+        time_type_id_(underlying_schema_->fields()[time_col_index_]->type()->id()),
         key_type_id_(key_col_index.size()),
         key_hasher_(key_hasher),
         node_(node),
@@ -534,7 +532,6 @@ class InputState : public util::SerialSequencingQueue::Processor {
     for (size_t k = 0; k < key_col_index_.size(); k++) {
       key_type_id_[k] = underlying_schema_->fields()[key_col_index_[k]]->type()->id();
     }
-    time_type_id_ = underlying_schema_->fields()[time_col_index_]->type()->id();
   }
 
   static Result<std::unique_ptr<InputState>> Make(

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1877,31 +1877,30 @@ TEST(AsofJoinTest, DestroyNonStartedAsofJoinNode) {
       DeclarationToStatus(std::move(sink)));
 }
 
-TEST(AsofJoinTest, Dictionary) {
-  // Create left source table
+TEST(AsofJoinTest, SimpleDictionary) {
   auto l_on = DictArrayFromJSON(dictionary(int32(), int32()), R"([2, null, 1, 3, 0, 0])", R"([12, 6, null, 7])");
   auto l_schema = schema({field("on", dictionary(int32(), int32()))});
   auto l_table = Table::Make(l_schema, {l_on});
   
-  // Create right source table
   auto r_on = ArrayFromJSON(int32(), R"([3, 4, 6, 6, 10])");
   auto r_payload = ArrayFromJSON(utf8(), R"(["a", "b", "c", null, "z"])");
   auto r_schema = schema({field("on", int32()), field("payload", utf8())});
   auto r_table = Table::Make(r_schema, {r_on, r_payload});
   
-  // Create table with expected results
   auto exp_on = DictArrayFromJSON(dictionary(int32(), int32()), R"([null, null, 0, 1, 2, 2])", R"([6, 7, 12])");
   auto exp_payload = ArrayFromJSON(utf8(), R"(["a", "a", "c", "z", null, null])");
   auto exp_schema = schema({field("key", int32()), field("payload", utf8())});
   auto exp_table = Table::Make(exp_schema, {exp_on, exp_payload});
 
-  // Set up asof join declaration
-  Declaration left("table_source", TableSourceNodeOptions(l_table));
-  Declaration right("table_source", TableSourceNodeOptions(r_table));
-  AsofJoinNodeOptions join_options({{"on", {}}, {"on", {}}}, 5);
-  auto asofjoin = Declaration("asofjoin", {std::move(left), std::move(right)}, std::move(join_options));
+  std::shared_ptr<Table> result;
+  {
+    Declaration left("table_source", TableSourceNodeOptions(l_table));
+    Declaration right("table_source", TableSourceNodeOptions(r_table));
+    AsofJoinNodeOptions join_options({{"on", {}}, {"on", {}}}, 5);
+    auto asofjoin = Declaration("asofjoin", {std::move(left), std::move(right)}, std::move(join_options));
 
-  ASSERT_OK_AND_ASSIGN(auto result, DeclarationToTable(asofjoin));
+    ASSERT_OK_AND_ASSIGN(result, DeclarationToTable(asofjoin));
+  }
 
   AssertTablesEqual(*exp_table, *result);
 }


### PR DESCRIPTION
I added a test for an asof join on a dictionary column. It creates two `Table`s, joins them, and checks that the result is what we expect.

The other tests are much more comprehensive and tend to use `BatchesWithSchema`s over `Table`s. In the future, I will definitely have to switch my test over to this style (and write more of them) to test parallel execution and different batch sizes.

I spent a good amount of time trying to write a test like theirs, but the testing code has a bunch of macros and callbacks that are kind of hard to trace. For now, this should be enough to start working on the implementation.