### PR TITLE
[C++] Fix Boolean Compute Bug

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
@@ -52,19 +52,22 @@ void CheckBooleanScalarArrayBinary(std::string func_name, Datum array) {
 }
 
 template <template <typename> class BitOp>
-void CheckChunkedOffsets(std::string func_name, std::shared_ptr<Array> trues, std::shared_ptr<Array> falses) {
+void CheckChunkedOffsets(const std::string& func_name,
+    const std::shared_ptr<Array>& a, const std::shared_ptr<Array>& b) {
   BitOp<bool> op;
 
   for (int64_t left_offset = 0; left_offset < 8; left_offset++) {
     for (int64_t right_offset = 0; right_offset < 8; right_offset++) {
       for (int64_t length = std::max(left_offset, right_offset) + 1; length <= 24; length++) {
         auto left = std::make_shared<ChunkedArray>(
-            ArrayVector{falses->Slice(0, left_offset),
-                        trues->Slice(left_offset, length - left_offset)});
-        auto right = trues->Slice(right_offset, length);
+            ArrayVector{a->Slice(0, left_offset),
+                        b->Slice(left_offset, length - left_offset)});
+        auto right = a->Slice(right_offset, length);
         ASSERT_OK_AND_ASSIGN(Datum result, CallFunction(func_name, {left, right}));
         for (int64_t i = 0; i < length; i++) {
-          BooleanScalar expected(op(i >= left_offset, true));
+          BooleanScalar l = checked_cast<BooleanScalar&>(*left->GetScalar(i).ValueOrDie());
+          BooleanScalar r = checked_cast<BooleanScalar&>(*right->GetScalar(i).ValueOrDie());
+          BooleanScalar expected(op(l.value, r.value));
           ASSERT_TRUE(result.chunked_array()->GetScalar(i).ValueOrDie()->Equals(expected));
         }
       }
@@ -180,9 +183,13 @@ TEST(TestBooleanKernel, ChunkedOffsets) {
   ASSERT_OK(builder.AppendValues(std::vector<bool>(32, false)));
   ASSERT_OK(builder.Finish(&falses));
 
-  CheckChunkedOffsets<std::bit_and>("and", trues, falses);
-  CheckChunkedOffsets<std::bit_or>("or", trues, falses);
-  CheckChunkedOffsets<std::bit_xor>("xor", trues, falses);
+  for (const auto& a : {trues, falses}) {
+    for (const auto& b : {trues, falses}) {
+      CheckChunkedOffsets<std::bit_and>("and", a, b);
+      CheckChunkedOffsets<std::bit_or>("or", a, b);
+      CheckChunkedOffsets<std::bit_xor>("xor", a, b);
+    }
+  }
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
@@ -151,10 +151,23 @@ TEST(TestBooleanKernel, KleeneOr) {
   CheckBooleanScalarArrayBinary("or_kleene", left);
 }
 
-TEST(TestBooleanKernel, ChunkedAnd) {
+TEST(TestBooleanKernel, ChunkedAndOffset1) {
   auto true_true = ArrayFromJSON(boolean(), "[true, true]");
   auto false_true = std::make_shared<ChunkedArray>(ArrayVector{
       ArrayFromJSON(boolean(), "[false]"), true_true->Slice(1)});
+  auto expected = std::make_shared<ChunkedArray>(
+      ArrayVector{ArrayFromJSON(boolean(), "[false, true]")});
+
+  ASSERT_OK_AND_ASSIGN(Datum actual, CallFunction("and", {true_true, false_true}));
+  ValidateOutput(actual);
+  AssertDatumsEqual(expected, actual, /*verbose=*/true);
+}
+
+TEST(TestBooleanKernel, ChunkedAndOffset2) {
+  auto true_true = ArrayFromJSON(boolean(), "[true, true]");
+  auto true_true_true = ArrayFromJSON(boolean(), "[true, true, true]");
+  auto false_true = std::make_shared<ChunkedArray>(ArrayVector{
+      ArrayFromJSON(boolean(), "[false]"), true_true_true->Slice(2)});
   auto expected = std::make_shared<ChunkedArray>(
       ArrayVector{ArrayFromJSON(boolean(), "[false, true]")});
 

--- a/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean_test.cc
@@ -151,5 +151,17 @@ TEST(TestBooleanKernel, KleeneOr) {
   CheckBooleanScalarArrayBinary("or_kleene", left);
 }
 
+TEST(TestBooleanKernel, ChunkedAnd) {
+  auto true_true = ArrayFromJSON(boolean(), "[true, true]");
+  auto false_true = std::make_shared<ChunkedArray>(ArrayVector{
+      ArrayFromJSON(boolean(), "[false]"), true_true->Slice(1)});
+  auto expected = std::make_shared<ChunkedArray>(
+      ArrayVector{ArrayFromJSON(boolean(), "[false, true]")});
+
+  ASSERT_OK_AND_ASSIGN(Datum actual, CallFunction("and", {true_true, false_true}));
+  ValidateOutput(actual);
+  AssertDatumsEqual(expected, actual, /*verbose=*/true);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -328,12 +328,6 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
 
 namespace {
 
-// For every bit in the mask that is set, the corresponding bit from 'new_byte' is taken.
-// For every bit in the mask that is not set, the corresponding bit from 'old_val' is taken.
-uint8_t merge(uint8_t old_byte, uint8_t new_byte, uint8_t mask) {
-  return (old_byte & ~mask) | (new_byte & mask);
-}
-
 template <template <typename> class BitOp>
 void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                      int64_t right_offset, uint8_t* out, int64_t out_offset,
@@ -342,39 +336,61 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
   DCHECK_EQ(left_offset % 8, right_offset % 8);
   DCHECK_EQ(left_offset % 8, out_offset % 8);
 
-  const int64_t nbytes = bit_util::CoveringBytes(left_offset, length);
-  const int64_t start_bit = left_offset % 8;
+  int64_t nbytes = bit_util::CoveringBytes(left_offset, length);
+  if (nbytes == 0)
+    return;
+
+  int64_t offset = left_offset % 8;
   left += left_offset / 8;
   right += right_offset / 8;
   out += out_offset / 8;
 
-  // Handle case where range is contained in a single byte
-  if (nbytes == 0) {
-    return;
-  } else if (nbytes == 1) {
-    uint64_t bits = bit_util::TrailingBits(0xff, static_cast<int>(length));
-    uint8_t mask = static_cast<uint8_t>(bits << start_bit);
-    out[0] = merge(out[0], op(left[0], right[0]), mask);
-    return;
+  {
+    // Handle the first byte
+    uint64_t bits_in_first_byte = std::min(length, offset == 0 ? 8 : 8 - offset);
+    uint8_t first_byte_out = op(left[0], right[0]);
+
+    // Write to the last `bits_in_first_byte` bits to the first byte of `out`
+    internal::BitmapWriter first_byte_writer(out, offset, bits_in_first_byte);
+    for (uint64_t i = 0; i < bits_in_first_byte; i++) {
+      if (bit_util::GetBitFromByte(first_byte_out, offset + i)) {
+        first_byte_writer.Set();
+      } else {
+        first_byte_writer.Clear();
+      }
+      first_byte_writer.Next();
+    }
+    first_byte_writer.Finish();
   }
 
-  // Handle the first byte separately, as it may not be fully covered
-  uint8_t first_byte_mask = 0xff << start_bit;
-  out[0] |= op(left[0], right[0]) & first_byte_mask;
+  // If there is only one byte, we are done
+  if (nbytes == 1)
+    return;
 
-  // Handle middle bytes (all fully covered)
+  // Handle middle bytes
   for (int64_t i = 1; i < nbytes - 1; ++i) {
     out[i] = op(left[i], right[i]);
   }
 
-  // Handle the last byte
-  int bits_in_last_byte = (start_bit + length) % 8;
-  if (bits_in_last_byte == 0) {
-    bits_in_last_byte = 8;
+  {
+    // Handle the last byte
+    uint64_t last_offset = (offset + length) % 8;
+    uint64_t bits_in_last_byte = last_offset == 0 ? 8 : last_offset;
+    uint64_t last_byte_offset = 8 * (nbytes - 1);
+    uint8_t last_byte_out = op(left[nbytes - 1], right[nbytes - 1]);
+
+    // Write to the first `bits_in_last_byte` bits to the last byte of `out`
+    internal::BitmapWriter last_byte_writer(out, last_byte_offset, bits_in_last_byte);
+    for (uint64_t i = 0; i < bits_in_last_byte; i++) {
+      if (bit_util::GetBitFromByte(last_byte_out, i)) {
+        last_byte_writer.Set();
+      } else {
+        last_byte_writer.Clear();
+      }
+      last_byte_writer.Next();
+    }
+    last_byte_writer.Finish();
   }
-  uint8_t last_byte_mask = static_cast<uint8_t>(bit_util::TrailingBits(0xff, bits_in_last_byte));
-  out[nbytes - 1] = merge(
-    out[nbytes - 1], op(left[nbytes - 1], right[nbytes - 1]), last_byte_mask);
 }
 
 template <template <typename> class BitOp>

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -350,7 +350,7 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
     uint64_t bits_in_first_byte = std::min(length, offset == 0 ? 8 : 8 - offset);
     uint8_t first_byte_out = op(left[0], right[0]);
 
-    // Write to the last `bits_in_first_byte` bits to the first byte of `out`
+    // Write to the last `bits_in_first_byte` bits of the first byte of `out`
     internal::BitmapWriter first_byte_writer(out, offset, bits_in_first_byte);
     for (uint64_t i = 0; i < bits_in_first_byte; i++) {
       if (bit_util::GetBitFromByte(first_byte_out, offset + i)) {
@@ -379,7 +379,7 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
     uint64_t last_byte_offset = 8 * (nbytes - 1);
     uint8_t last_byte_out = op(left[nbytes - 1], right[nbytes - 1]);
 
-    // Write to the first `bits_in_last_byte` bits to the last byte of `out`
+    // Write to the first `bits_in_last_byte` bits of the last byte of `out`
     internal::BitmapWriter last_byte_writer(out, last_byte_offset, bits_in_last_byte);
     for (uint64_t i = 0; i < bits_in_last_byte; i++) {
       if (bit_util::GetBitFromByte(last_byte_out, i)) {

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -337,8 +337,9 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
   DCHECK_EQ(left_offset % 8, out_offset % 8);
 
   int64_t nbytes = bit_util::CoveringBytes(left_offset, length);
-  if (nbytes == 0)
+  if (nbytes == 0) {
     return;
+  }
 
   int64_t offset = left_offset % 8;
   left += left_offset / 8;
@@ -364,8 +365,9 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
   }
 
   // If there is only one byte, we are done
-  if (nbytes == 1)
+  if (nbytes == 1) {
     return;
+  }
 
   // Handle middle bytes
   for (int64_t i = 1; i < nbytes - 1; ++i) {

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -328,6 +328,22 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
 
 namespace {
 
+// Writes `bit_count` bits of `byte` (starting a `offset`) to
+// `out` (starting at `offset`). `offset` measures the distance
+// in bits from the least significant bit.
+void WritePartialByte(uint8_t* out, int64_t offset, uint8_t byte, int64_t bit_count) {
+  internal::BitmapWriter writer(out, offset, bit_count);
+  for (int64_t i = 0; i < bit_count; i++) {
+    if (bit_util::GetBitFromByte(byte, offset + i)) {
+      writer.Set();
+    } else {
+      writer.Clear();
+    }
+    writer.Next();
+  }
+  writer.Finish();
+}
+
 template <template <typename> class BitOp>
 void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                      int64_t right_offset, uint8_t* out, int64_t out_offset,
@@ -346,23 +362,10 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
   right += right_offset / 8;
   out += out_offset / 8;
 
-  {
-    // Handle the first byte
-    uint64_t bits_in_first_byte = std::min(length, offset == 0 ? 8 : 8 - offset);
-    uint8_t first_byte_out = op(left[0], right[0]);
-
-    // Write to the last `bits_in_first_byte` bits of the first byte of `out`
-    internal::BitmapWriter first_byte_writer(out, offset, bits_in_first_byte);
-    for (uint64_t i = 0; i < bits_in_first_byte; i++) {
-      if (bit_util::GetBitFromByte(first_byte_out, offset + i)) {
-        first_byte_writer.Set();
-      } else {
-        first_byte_writer.Clear();
-      }
-      first_byte_writer.Next();
-    }
-    first_byte_writer.Finish();
-  }
+  // Handle the first byte
+  int64_t bits_in_first_byte = std::min(length, offset == 0 ? 8 : 8 - offset);
+  uint8_t first_byte_out = op(left[0], right[0]);
+  WritePartialByte(out, offset, first_byte_out, bits_in_first_byte);
 
   // If there is only one byte, we are done
   if (nbytes == 1) {
@@ -374,25 +377,11 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
     out[i] = op(left[i], right[i]);
   }
 
-  {
-    // Handle the last byte
-    uint64_t last_offset = (offset + length) % 8;
-    uint64_t bits_in_last_byte = last_offset == 0 ? 8 : last_offset;
-    uint64_t last_byte_offset = 8 * (nbytes - 1);
-    uint8_t last_byte_out = op(left[nbytes - 1], right[nbytes - 1]);
-
-    // Write to the first `bits_in_last_byte` bits of the last byte of `out`
-    internal::BitmapWriter last_byte_writer(out, last_byte_offset, bits_in_last_byte);
-    for (uint64_t i = 0; i < bits_in_last_byte; i++) {
-      if (bit_util::GetBitFromByte(last_byte_out, i)) {
-        last_byte_writer.Set();
-      } else {
-        last_byte_writer.Clear();
-      }
-      last_byte_writer.Next();
-    }
-    last_byte_writer.Finish();
-  }
+  // Handle the last byte
+  uint64_t end_offset = (offset + length) % 8;
+  uint64_t bits_in_last_byte = end_offset == 0 ? 8 : end_offset;
+  uint8_t last_byte_out = op(left[nbytes - 1], right[nbytes - 1]);
+  WritePartialByte(&out[nbytes - 1], 0, last_byte_out, bits_in_last_byte);
 }
 
 template <template <typename> class BitOp>

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -392,15 +392,17 @@ class RunEndEncodedArraySpan {
   /// \warning Avoid calling end() in a loop, as it will recompute the physical
   /// length of the array on each call (O(log N) cost per call).
   ///
-  /// \par You can write your loops like this instead:
+  /// You can write your loops like this instead:
+  ///
   /// \code
   /// for (auto it = array.begin(), end = array.end(); it != end; ++it) {
   ///   // ...
   /// }
   /// \endcode
   ///
-  /// \par Or this version that does not look like idiomatic C++, but removes
+  /// Or this version that does not look like idiomatic C++, but removes
   /// the need for calling end() completely:
+  ///
   /// \code
   /// for (auto it = array.begin(); !it.is_end(array); ++it) {
   ///   // ...

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1804,6 +1804,19 @@ def test_logical():
     assert pc.invert(a) == pa.array([False, True, True, None])
 
 
+def test_logical_with_offset():
+    true_true = pa.array([True, True])
+    false_false = pa.array([False, False])
+    false_true = pa.chunked_array([
+        [False],
+        true_true.slice(1),
+    ])
+
+    assert pc.and_(true_true, false_true) == pa.chunked_array([[False, True]])
+    assert pc.or_(false_false, false_true) == pa.chunked_array([[False, True]])
+    assert pc.xor(true_true, false_true) == pa.chunked_array([[True, False]])
+
+
 def test_dictionary_decode():
     array = pa.array(["a", "a", "b", "c", "b"])
     dictionary_array = array.dictionary_encode()


### PR DESCRIPTION
### Rationale for this change

```python
import pyarrow as pa
import pyarrow.compute as pc

true_true = pa.array([True, True])
false_true = pa.chunked_array([
    [False],
    pa.array([True, True]).slice(1),
])

pc.and_(true_true, false_true)
```
produces
```
[
  [
    true,
    true
  ]
]
```
which is not correct (the output should be `[false, true]`).

This bug is caused by the `AlignedBitmapOp` function in `arrow/util/bitmap_ops.cc`. It accepts three bitmaps and is supposed to apply the bit operation to the two input bitmaps and store the result in the output bitmap. The three bitmaps must have the same alignment but need not be byte-aligned, so we could have `0 != left_offset % 8 == right_offset % 8 == out_offset % 8`.

The previous implementation rounded the start and end points of the bitmaps to the nearest byte. For example, if the offset was 4 and the length was 10, we might start with
```
             ---- ------
left:    11111111 11111111
right:   11111111 11111111
out:     00000000 00000000
```
The previous implementation would read each byte in `left`, `std::bit_and` it with the corresponding byte in `right` and write the result to `out` giving
```
             ---- ------
out:     11111111 11111111
```
But the first 4 bits and the last 2 bits of `out` shouldn't be touched since they aren't in the bitmap. `out` should really look like
```
             ---- ------
out:     00001111 11111100
```

In the Python example I give above, the computation is split into two chunks that contain one bit each. The first has inputs
```
         -
left:    11xxxxxx
right:   0xxxxxxx
```
and results in
```
out:     0xxxxxxx
```
where `x` could be anything. The second bit is then computed its own chunk with
```
          -
left:    11xxxxxx
right:   11xxxxxx
```
Since this chunk has length 1,`out` _should_ only have its second bit touched (and should contain `01xxxxxx`), but the whole byte is anded together and we get
```
out:     11xxxxxx
```
which is bad because it overwrites the first bit we just computed.

### What changes are included in this PR?

This PR modifies the `AlignedBitmapOp` function so that it does not modify bits outside of its output range. It does this by using a `BitmapWriter` to modify only certain bits of the fist and last bytes in `out`. The middle bytes are handled as before.

### Are these changes tested?

Yes. This PR includes C++ and Python tests for compute functions on boolean arrays with nonzero offsets.

### Are there any user-facing changes?

No.
